### PR TITLE
Add "extraHeaders" to opt_extraInfoSpec

### DIFF
--- a/background.js
+++ b/background.js
@@ -55,7 +55,7 @@ function registerListener() {
     chrome.webRequest.onBeforeSendHeaders.addListener(
         handleBeforeSendHeaders,
         {urls:filter},
-        ["blocking","requestHeaders"]
+        ["blocking","requestHeaders","extraHeaders"]
     );
     console.log("registered listener.");
 }


### PR DESCRIPTION
Chrome 79 requries this option to be present in order to circumvent newly introduced CORS restrictions.

https://developer.chrome.com/extensions/webRequest

